### PR TITLE
Build installed gems from clean worktree

### DIFF
--- a/bake/gem.rb
+++ b/bake/gem.rb
@@ -31,8 +31,14 @@ end
 # Build and install the gem into system gems.
 # @parameter local [Boolean] only use locally available caches.
 def install(local: false)
-	# For installing the gem, don't bother with signinng it:
-	path = @helper.build_gem(signing_key: false)
+	changes = @helper.uncommitted_changes
+	
+	if changes.any?
+		Console.warn(self, "Installing from clean git worktree; uncommitted changes are not included in the installed gem.", changes: changes.map(&:chomp))
+	end
+	
+	# For installing the gem, don't bother with signing it:
+	path = @helper.build_gem_in_worktree(signing_key: false)
 	
 	arguments = []
 	arguments << "--local" if local

--- a/lib/bake/gem/helper.rb
+++ b/lib/bake/gem/helper.rb
@@ -151,13 +151,19 @@ module Bake
 			# @returns [Boolean] True if the repository is clean.
 			# @raises [RuntimeError] If there are uncommitted changes in the repository.
 			def guard_clean
-				lines = readlines("git", "status", "--porcelain", chdir: @root)
+				lines = uncommitted_changes
 				
 				if lines.any?
 					raise "Repository has uncommited changes!\n#{lines.join('')}"
 				end
 				
 				return true
+			end
+			
+			# Get the list of uncommitted changes in the repository.
+			# @returns [Array(String)] The porcelain status lines for uncommitted changes.
+			def uncommitted_changes
+				readlines("git", "status", "--porcelain", chdir: @root)
 			end
 			
 			# Verify that the last commit was not a version bump.

--- a/test/bake/gem/helper.rb
+++ b/test/bake/gem/helper.rb
@@ -102,6 +102,12 @@ describe Bake::Gem::Helper do
 			expect(helper.guard_clean).to be_truthy
 		end
 		
+		it "can list uncommitted changes" do
+			File.write(File.expand_path("readme.md", helper.root), "Hello, World!")
+			
+			expect(helper.uncommitted_changes).to be == ["?? readme.md\n"]
+		end
+		
 		it "raises an error if repository is dirty" do
 			File.write(File.expand_path("readme.md", helper.root), "Hello, World!")
 			


### PR DESCRIPTION
## Summary
- build `gem:install` artifacts from a clean git worktree like `gem:release`
- warn when uncommitted local changes will not be included in the installed gem
- expose and test helper support for checking uncommitted git status

## Tests
- `bundle exec sus`