### PR TITLE
Document command execution error initializer

### DIFF
--- a/lib/bake/gem/shell.rb
+++ b/lib/bake/gem/shell.rb
@@ -11,6 +11,9 @@ module Bake
 	module Gem
 		# Exception raised when a command execution fails.
 		class CommandExecutionError < RuntimeError
+			# Initialize the exception with the specified message and process status.
+			# @parameter message [String] The error message.
+			# @parameter status [Process::Status] The status object of the failed command.
 			def initialize(message, status)
 				super(message)
 				@status = status


### PR DESCRIPTION
## Summary
- add missing documentation for `CommandExecutionError#initialize`

## Tests
- `bundle exec bake decode:index:coverage lib`
- `bundle exec rubocop lib/bake/gem/shell.rb`